### PR TITLE
LG-83 updated content field input types to autocomplete

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -21,7 +21,6 @@ dependencies:
     - field.field.node.event.field_show_on_calendar
     - node.type.event
   module:
-    - chosen_field
     - datetime
     - file
     - link
@@ -104,10 +103,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_locations:
-    type: options_select
+    type: entity_reference_autocomplete
     weight: 1
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_media_contact:
     type: entity_reference_paragraphs
@@ -125,7 +128,9 @@ content:
     type: metatag_firehose
     weight: 20
     region: content
-    settings: {  }
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_recurring_event:
     type: options_select
@@ -134,10 +139,14 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_related_departments:
-    type: chosen_select
+    type: entity_reference_autocomplete_tags
     weight: 2
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_related_documents:
     type: file_generic
@@ -206,5 +215,10 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -46,16 +46,22 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
   field_lex_site_nav:
-    type: options_select
+    type: entity_reference_autocomplete
     weight: 7
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
     weight: 9
     region: content
-    settings: {  }
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_related_departments:
     type: entity_reference_autocomplete_tags
@@ -111,5 +117,10 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_form_display.node.meeting.default.yml
+++ b/config/sync/core.entity_form_display.node.meeting.default.yml
@@ -18,7 +18,6 @@ dependencies:
     - field.field.node.meeting.field_show_on_calendar
     - node.type.meeting
   module:
-    - chosen_field
     - datetime
     - file
     - metatag
@@ -76,16 +75,22 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_locations:
-    type: options_select
+    type: entity_reference_autocomplete
     weight: 1
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
     weight: 15
     region: content
-    settings: {  }
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_recurring_event:
     type: options_select
@@ -94,10 +99,14 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_related_departments:
-    type: chosen_select
+    type: entity_reference_autocomplete_tags
     weight: 2
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_related_documents:
     type: file_generic
@@ -166,6 +175,11 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   field_external_id: true

--- a/config/sync/core.entity_form_display.node.news_article.default.yml
+++ b/config/sync/core.entity_form_display.node.news_article.default.yml
@@ -14,7 +14,6 @@ dependencies:
     - image.style.thumbnail
     - node.type.news_article
   module:
-    - chosen_field
     - file
     - image
     - metatag
@@ -85,13 +84,19 @@ content:
     type: metatag_firehose
     weight: 12
     region: content
-    settings: {  }
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_related_departments:
-    type: chosen_select
+    type: entity_reference_autocomplete_tags
     weight: 2
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_related_documents:
     type: file_generic
@@ -144,5 +149,10 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_form_display.node.organization_page.default.yml
+++ b/config/sync/core.entity_form_display.node.organization_page.default.yml
@@ -68,10 +68,14 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
   field_lex_site_nav:
-    type: options_select
+    type: entity_reference_autocomplete
     weight: 7
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
@@ -82,10 +86,14 @@ content:
       use_details: true
     third_party_settings: {  }
   field_office_to_contact:
-    type: options_select
+    type: entity_reference_autocomplete_tags
     weight: 5
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_organization_taxonomy_term:
     type: entity_reference_autocomplete

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -22,7 +22,6 @@ dependencies:
     - image.style.thumbnail
     - node.type.page
   module:
-    - chosen_field
     - file
     - iframe
     - image
@@ -107,7 +106,7 @@ content:
       use_details: true
     third_party_settings: {  }
   field_office_to_contact:
-    type: entity_reference_autocomplete
+    type: entity_reference_autocomplete_tags
     weight: 7
     region: content
     settings:
@@ -139,10 +138,14 @@ content:
       default_paragraph_type: ''
     third_party_settings: {  }
   field_related_departments:
-    type: chosen_select
+    type: entity_reference_autocomplete_tags
     weight: 8
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_related_documents:
     type: file_generic
@@ -203,6 +206,11 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   body: true


### PR DESCRIPTION
  - updated the related departments to be autocomplete for Events, Full-Bleed landing page, Meetings/notice, News, and Service Guide content types
  - updated Navigation Topic to be autocomplete for Orgainizations, Service Guide, and full bleed landing page content types.
  - updated Office to Contact to be autocomplete for Organization, and Service Guide content types.
  - This will make those fields have the same input type across all content types which use them.