### PR TITLE
Adds a PR template to repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary / Approach
+<!-- Include a summary of your changes that expands upon the title. -->
+
+## Testing Instruction(s)
+<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
+
+## Screenshots
+<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
+
+## Metadata
+<!-- Please fill out ALL metadata. Use N/A when necessary. -->
+| Question | Answer |
+|----------|--------|
+| Did you perform a self-review of this PR? |
+| Documentation reflects changes? |
+| Unit/Functional tests reflect changes? |
+| Did you perform browser testing? |
+| Did you provide detail in the summary on how and where to test this branch? |
+| Relevant links | JIRA issue, bug reports, security alerts, etc.


### PR DESCRIPTION
This template will automatically populate the PR template when merged in for the future. I think we should standardize what we put in the PR description. Keeps us accountable.