### PR TITLE
LG-113 Fixes card buttons across breakpoints

### DIFF
--- a/web/themes/custom/lex/old_scss/_layout.sass
+++ b/web/themes/custom/lex/old_scss/_layout.sass
@@ -261,7 +261,7 @@ main
 
 @media (max-width: $screen-phone-max)
   .lex-region-content
-    figure, img
+    figure, img:not(.button-img)
       &.align-left, &.align-right
         float: none
       margin: 1em 0

--- a/web/themes/custom/lex/scss/molecules/_card_button.scss
+++ b/web/themes/custom/lex/scss/molecules/_card_button.scss
@@ -1,55 +1,47 @@
 .card-button {
-    border: 1px solid color(med-blue);
-    width: 250px;
-     @include screens-above(xxl) {
-        width: 400px;
-    }
-    background-color: color(white);
+  background-color: color(white);
+  border: 1px solid color(med-blue);
+  color: color(med-blue);
+  display: block !important;
+  width: 250px;
+
+  .button-heading {
     color: color(med-blue);
-    display: block !important;
+    font-size: 1.1em !important;
+    margin: 10px 0 5px;
+    min-height: 2.5em;
+
+    @include lineclamp($lines: 2);
+  }
+
+  img {
+    height: 190px;
+    width: 100%;
+  }
+
+  .description {
+    @include lineclamp($lines: 2);
+
+    div {
+      padding-bottom: 10px;
+      display: block !important;
+
+      p {
+        min-height: 4.5em;
+
+        @include lineclamp($lines: 3);
+      }
+    }
+  }
+
+  &:hover {
+    background-color: color(yellow);
+    border: none;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.55) !important;
+    color: color(white);
 
     .button-heading {
-        color: color(med-blue);
-        margin: 10px 0 5px;
-        min-height: 2.5em;
-        overflow: hidden;
-        -o-text-overflow: ellipsis;
-        text-overflow: ellipsis;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        font-size: 1.1em !important;
+      color: color(white);
     }
-
-    img {
-        height: 190px;
-        width: 100%;
-    }
-
-    .description {
-        div {
-            padding-bottom: 10px;
-            display: block !important;
-            p {
-                min-height: 4.5em;
-                overflow: hidden;
-                -o-text-overflow: ellipsis;
-                text-overflow: ellipsis;
-                display: -webkit-box;
-                -webkit-line-clamp: 3;
-                -webkit-box-orient: vertical;
-            }
-        }
-    }
-
-    &:hover {
-        background-color: color(yellow);
-        box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.55) !important;
-        color: color(white);
-        border: none;
-
-        .button-heading {
-            color: color(white);
-        }
-    }
+  }
 }

--- a/web/themes/custom/lex/scss/molecules/_icon_button_with_description.scss
+++ b/web/themes/custom/lex/scss/molecules/_icon_button_with_description.scss
@@ -1,49 +1,37 @@
 .icon-desc-button {
-    height: auto;
-    width: 250px;
-    background-color: color(med-blue);
+  background-color: color(med-blue);
+  color: color(white);
+  height: auto;
+  width: 250px;
+
+  .icon-img-button {
+    margin-left: 0.25em;
+    margin-top: 1em;
+  }
+
+  .button-heading {
     color: color(white);
+    margin: 0 0 15px 0;
+  }
+  .row {
+    padding-top: 15px;
+  }
 
-    .icon-img-button {
-        margin-top: 1em;
-        margin-left: .25em;
-        transform: scale(4);
-    }
-    
-    .button-heading {
-        margin: 0 0 15px 0;
-        color: color(white);
-    }
-    .row {
-        padding-top: 15px;
-    }
+  .description {
+    font-size: 1rem;
+  }
 
-    .description {
-        font-size: 1rem;
-    }
+  .button-icon {
+    font-size: 1.6em;
+  }
 
-    .button-icon {
-        font-size: 1.6em;
-    }
+  .button-arrow {
+    float: right;
+    margin-top: 3px;
+  }
 
-    .button-arrow {
-        float: right;
-        margin-top: 3px;
-    }
-
-     &:hover {
-        background-color: #E1B111;
-        height: auto;
-        box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.55) !important;
-
-        .row {
-            padding: 20px 0 5px;
-        }
-
-        .description {
-            div {
-                padding-bottom: 15px;
-            }
-        }
-    }
+  &:hover {
+    background-color: #e1b111;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.55) !important;
+  }
 }


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->

Card buttons were changing dimensions on larger screens, as well as stretching out their images. It also fixed the styling of the same card button paragraphs when they didn't have images. Removing unneeded and poor hovering effects.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
You can compare the changes between the multi dev and production

https://www.lexingtonky.gov/media-center

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

<img width="608" alt="Screenshot 2023-07-05 at 4 25 17 PM" src="https://github.com/lfucg/lexingtonky.gov/assets/43646355/85dad50b-f378-4394-8de5-8896ab656209">

<img width="1512" alt="Screenshot 2023-07-05 at 4 25 56 PM" src="https://github.com/lfucg/lexingtonky.gov/assets/43646355/1107c79b-41a6-46f2-9480-af3ac7b7777e">

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you perform a self-review of this PR? | Yes
| Documentation reflects changes? | No need for documentation changes
| Unit/Functional tests reflect changes? | No tests needed for the changes
| Did you perform browser testing? | Yes
| Did you provide detail in the summary on how and where to test this branch? | Yes
| Relevant links | JIRA issue, bug reports, security alerts, etc.
https://apaxsoftware.atlassian.net/jira/software/c/projects/LG/boards/68?modal=detail&selectedIssue=LG-113
https://www.lexingtonky.gov/departments/parks-recreation
https://www.lexingtonky.gov/media-center

