### PR TITLE
Two update hooks to remove old News and Final Orders

### DIFF
--- a/web/modules/custom/lex_custom/lex_custom.module
+++ b/web/modules/custom/lex_custom/lex_custom.module
@@ -5,6 +5,7 @@
  * Contains lex_custom.module.
  */
 
+use Drupal\Core\Batch\BatchBuilder;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
@@ -123,4 +124,61 @@ function lex_custom_update_9402() {
 
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('moderation_state', 'taxonomy_term', 'workbench_moderation', $field_storage_definition);
+}
+
+/**
+ * Delete all news items prior to 2021 from database.
+ */
+function lex_custom_update_9503(&$sandbox) {
+  return _delete_entities_prior_to_date('node', 'news_article', '2021-01-01', $sandbox);
+}
+
+/**
+ * Delete all final order items prior to 2019 from database.
+ */
+function lex_custom_update_9504(&$sandbox) {
+  return _delete_entities_prior_to_date('node', 'final_order', '2019-01-01', $sandbox);
+}
+
+/**
+ * Reusable delete function of all entity types.
+ *
+ * @param string $entity_type_id  The entity type id. I.e 'node', 'taxonomy_term'
+ * @param string $bundle Entity bundle id. I.e. 'page', 'news_article'.
+ * @param string $published_date Format YYYY-MM-DD
+ * 
+ * @return void
+ */ 
+function _delete_entities_prior_to_date($entity_type_id, $bundle, $published_date, $sandbox) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $date_limit = strtotime($published_date);
+
+  $entity_storage = $entity_type_manager->getStorage($entity_type_id);
+  $query = $entity_storage->getQuery()
+    ->condition("type", $bundle)
+    ->condition("created", $date_limit, "<");
+  $entity_ids = $query->execute();
+
+  if (empty($entity_ids)) {
+    $messenger = \Drupal::messenger();
+    $messenger->addStatus("No items found to delete.");
+    return t("All {$bundle} prior to {$published_date} have ALREADY been deleted.");
+  }
+
+  if (!isset($sandbox["progress"])) {
+    // This must be the first run. Initialize the sandbox.
+    $sandbox["progress"] = 0;
+    $sandbox["current_pk"] = 0;
+    $sandbox["max"] = count($entity_ids);
+  }
+
+  $entities = $entity_storage->loadMultiple($entity_ids);
+  foreach ($entities as $entity) {
+    $id = $entity->id();
+    $entity->delete();
+    $sandbox["progress"]++;
+    $sandbox["current_node"] = $id;
+  }
+  $sandbox["#finished"] = empty($sandbox["max"]) ? 1 : $sandbox["progress"] / $sandbox["max"];
+  return t("All {$bundle} prior to {$published_date} have been deleted.");
 }


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Add two update hooks to run with `drush updb` that will remove old news and final orders from the DB.
Thinking ahead, the function added gives ability to reuse the logic needed.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
If the hooks run automatically on the multidev sites, which I'm assuming they do, just visit and see if the items were deleted. Should be messages in the logs that it ran as well. 

If not you'll need to visit, update.php

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
![Screenshot 2023-07-12 at 10 46 18 AM](https://github.com/lfucg/lexingtonky.gov/assets/27921423/f0b56737-6cae-46b7-9230-e5689225df99)
Showing the items are all gone.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you perform a self-review of this PR? | yes
| Documentation reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | n/a
| Did you provide detail in the summary on how and where to test this branch? | yes
| Relevant links | [LG-74](https://apaxsoftware.atlassian.net/browse/LG-74)