### PR TITLE
LG-125 modifications

### DIFF
--- a/web/themes/custom/lex/old_scss/_layout.sass
+++ b/web/themes/custom/lex/old_scss/_layout.sass
@@ -175,7 +175,7 @@ main
   .path-node.bundle-organization_page &,
   .path-node.bundle-page &,
   .path-node.bundle-board_commission &
-    max-width: 1000px
+    max-width: 1150px
     margin: auto
 
     @media (min-width: $screen-desk-max)

--- a/web/themes/custom/lex/scss/molecules/_card_button.scss
+++ b/web/themes/custom/lex/scss/molecules/_card_button.scss
@@ -3,7 +3,7 @@
   border: 1px solid color(med-blue);
   color: color(med-blue);
   display: block !important;
-  width: 250px;
+  width: 225px;
 
   .button-heading {
     color: color(med-blue);
@@ -15,7 +15,7 @@
   }
 
   img {
-    height: 190px;
+    height: 171px;
     width: 100%;
   }
 

--- a/web/themes/custom/lex/scss/molecules/_icon_button_with_description.scss
+++ b/web/themes/custom/lex/scss/molecules/_icon_button_with_description.scss
@@ -2,7 +2,7 @@
   background-color: color(med-blue);
   color: color(white);
   height: auto;
-  width: 250px;
+  width: 225px;
 
   .icon-img-button {
     margin-left: 0.25em;


### PR DESCRIPTION
 - bumps non news pages to 1150px
 - takes down card button sizes down 10% in dimensions
 - takes down button link 10% in width

## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Adds width to non news pages, up to 1150px

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
No testing required other than inspecting the changes in the browser

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you perform a self-review of this PR? | Yes
| Documentation reflects changes? | N/A
| Unit/Functional tests reflect changes? | N/A
| Did you perform browser testing? | Yes
| Did you provide detail in the summary on how and where to test this branch? | Yes
| Relevant links | JIRA issue, bug reports, security alerts, etc. https://apaxsoftware.atlassian.net/jira/software/c/projects/LG/boards/68?selectedIssue=LG-125