### PR TITLE
Taylor/lg 128

### DIFF
--- a/web/themes/custom/lex/old_scss/_layout.sass
+++ b/web/themes/custom/lex/old_scss/_layout.sass
@@ -384,6 +384,10 @@ main
   >div
     margin-bottom: 2em
 
+  @media (max-width: 992px)
+    a:not(:nth-child(-n + 3))
+      display: none
+
 // Google translate
 #google_translate_element
   .goog-te-gadget-simple

--- a/web/themes/custom/lex/scss/_mixins.scss
+++ b/web/themes/custom/lex/scss/_mixins.scss
@@ -1,7 +1,7 @@
 @function strip-unit($value) {
   @return calc($value / ($value * 0 + 1px));
 }
-  
+
 @mixin fluid-type(
   $min-font-size,
   $max-font-size,

--- a/web/themes/custom/lex/scss/_typography.scss
+++ b/web/themes/custom/lex/scss/_typography.scss
@@ -57,7 +57,8 @@ a:not(
   .lex-calltoaction,
   .lex-font-standout,
   .contact-card-link,
-  .toolbar-icon
+  .toolbar-icon,
+  :has(.event-card)
   ) {
   color: color(med-blue);
 

--- a/web/themes/custom/lex/scss/main.scss
+++ b/web/themes/custom/lex/scss/main.scss
@@ -56,6 +56,7 @@ ol, ul, dl {
 .lex-region-events {
   background-color: color(light-gray);
   display: inline-block;
+  width: 100%;
 
   @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
     display: inline;
@@ -63,9 +64,9 @@ ol, ul, dl {
 }
 
 .lex-events-container {
+  margin: auto;
   min-height: 250px;
   position: relative;
-  margin: auto;
 }
 
 .section-padding:not(

--- a/web/themes/custom/lex/scss/molecules/_event_card.scss
+++ b/web/themes/custom/lex/scss/molecules/_event_card.scss
@@ -1,92 +1,104 @@
 .event-card {
-    background-color: color(med-blue);
+  background-color: color(med-blue);
+  color: color(white);
+  float: left;
+  height: 150px;
+  margin: 10px;
+  width: 350px;
+
+  img {
+    height: 25px;
+    width: 35px;
+  }
+
+  .row {
+    padding-top: 15px;
+  }
+
+  .button-heading {
     color: color(white);
-    float: left;
-    height: 150px;
-    margin: 10px;
-    width: 350px;
+    font-size: 20px;
+    margin: 0 0 15px 0;
 
-    img {
-        height: 25px;
-        width: 35px;
+    @include lineclamp($lines: 2);
+  }
+
+  .description {
+    font-size: 18px;
+
+    @include lineclamp($lines: 2);
+  }
+
+  .button-icon {
+    font-size: 1.4em;
+    margin-left: 10px;
+  }
+
+  .event-time {
+    display: block;
+    font-size: 0.9em;
+  }
+
+  .footer-text {
+    a {
+      color: #ffff;
+      font-size: 16px;
+      font-family: $font__roboto;
+      margin-top: 0.4em;
+      display: block;
     }
+  }
 
-    .row {
-        padding-top: 15px;
-    }
-
-    .button-heading {
-        color: color(white);
-        font-size: 20px;
-        margin: 0 0 15px 0;
-
-        @include lineclamp($lines: 2);
-    }
-
-    .description {
-        font-size: 18px;
-
-        @include lineclamp($lines: 2);
-    }
+  &:hover {
+    background-color: #e1b111;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.55) !important;
 
     .button-icon {
-        font-size: 1.4em;
-        margin-left: 10px;
+      transform: scale(1.01);
     }
-
-    .event-time {
-        display: block;
-        font-size: .9em;
-    }
-
-    .footer-text {
-        a {
-            color: #ffff;
-            font-size: 16px;
-            font-family: $font__roboto;
-            margin-top: .4em;
-            display: block;
-        }
-    }
-
-     &:hover {
-        background-color: #E1B111;
-        box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.55) !important;
-
-        .button-icon {
-            transform: scale(1.01);
-        }
-    }
+  }
 }
 
 .home-events-block {
-    h2 {
-        line-height: 1.2;
-        font-size: 2em;
-        color: #004585;
-        margin: 0 0 5px 12px;
-    }
+  h2 {
+    line-height: 1.2;
+    font-size: 2em;
+    color: #004585;
+    margin: 0 0 5px 12px;
+  }
 
-    .more-link {
-        float: left !important;
-        margin: 10px 100px 20px 10px;
-        text-transform: capitalize !important;
-        width: 200px;
-        white-space: nowrap;
+  .more-link {
+    float: left !important;
+    margin: 10px 100px 20px 10px;
+    text-transform: capitalize !important;
+    width: 200px;
+    white-space: nowrap;
 
-        a {
-            padding: 0.5em;
-        }
+    a {
+      padding: 0.5em;
     }
+  }
 }
 
-
 .meetings-block {
-    .event-card {
-        background-color: color(green);
+  .event-card {
+    background-color: color(green);
 
-        &:hover {
-            background-color: color(yellow);
-        }
+    &:hover {
+      background-color: color(yellow);
     }
+  }
+}
+
+.meetings-block,
+.home-events-block {
+  @media (max-width: 992px) {
+    margin: auto;
+
+    .lex-event-list {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+    }
+  }
 }

--- a/web/themes/custom/lex/templates/blocks/block--homeevents.html.twig
+++ b/web/themes/custom/lex/templates/blocks/block--homeevents.html.twig
@@ -1,4 +1,4 @@
-<div class="home-events-block events-block col-12 col-sm-8 offset-sm-2 col-lg-6 offset-lg-0 col-xl-8">
+<div class="home-events-block events-block col-12 col-sm-8 col-lg-6 offset-lg-0 col-xl-8">
     <h2>Events</h2>
-    {{content}}
+    {{ content }}
 </div>

--- a/web/themes/custom/lex/templates/blocks/block--homemeetings.html.twig
+++ b/web/themes/custom/lex/templates/blocks/block--homemeetings.html.twig
@@ -1,4 +1,4 @@
 <div class="home-events-block meetings-block col-12 col-sm-8 offset-sm-2 col-lg-6 offset-lg-0 col-xl-4">
     <h2>Meetings</h2>
-    {{content}}
+    {{ content }}
 </div>


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
This is a PR for tickets LG-128, and LG-121. This limits event cards on mobile to only display 3 tiles. This also adds styling tweaks to center cards on mobile, and eliminate card overflow for most standard mobile device sizes.
## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Inspecting and viewing on mobile viewport sizes

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
<img width="504" alt="Screenshot 2023-07-30 at 10 03 49 PM" src="https://github.com/lfucg/lexingtonky.gov/assets/43646355/1d8b9f2d-d437-47b1-8dee-2a43724ca29f">

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you perform a self-review of this PR? | Yes
| Documentation reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | Yes
| Did you provide detail in the summary on how and where to test this branch? | Yes
| Relevant links | JIRA issue, bug reports, security alerts, etc.https://apaxsoftware.atlassian.net/jira/software/c/projects/LG/boards/68?modal=detail&selectedIssue=LG-128
https://apaxsoftware.atlassian.net/jira/software/c/projects/LG/boards/68?modal=detail&selectedIssue=LG-121