### PR TITLE
LG-135 Shortens padding top across content types

### DIFF
--- a/web/themes/custom/lex/old_scss/_layout.sass
+++ b/web/themes/custom/lex/old_scss/_layout.sass
@@ -167,6 +167,7 @@ main
     flex-direction: column
     max-width: 940px
     margin: auto
+    padding: 2rem 5% !important
 
     > div:first-child,
     > div:last-child
@@ -177,6 +178,7 @@ main
   .path-node.bundle-board_commission &
     max-width: 1150px
     margin: auto
+    padding: 2rem 0 !important
 
     @media (min-width: $screen-desk-max)
       padding: $base_gutter 0


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Overwrites padding getting applied across the site, honestly, can't track down where from, so I assume bootstrap. This shrinks the padding top across content types.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Look at the padding between content titles and breadcrumbs

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
<img width="1512" alt="Screenshot 2023-08-23 at 5 13 31 PM" src="https://github.com/lfucg/lexingtonky.gov/assets/43646355/ffd712d2-7618-4909-961f-65eac6375de9">


## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you perform a self-review of this PR? | Yes
| Documentation reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | Yes
| Did you provide detail in the summary on how and where to test this branch? | Yes
| Relevant links | JIRA issue, bug reports, security alerts, etc. https://apaxsoftware.atlassian.net/jira/software/c/projects/LG/boards/68?modal=detail&selectedIssue=LG-135