### PR TITLE
Reverts Org news block, was accidentally overridden

### DIFF
--- a/config/sync/views.view.front_page_news.yml
+++ b/config/sync/views.view.front_page_news.yml
@@ -1307,7 +1307,22 @@ display:
         operator: AND
         groups:
           1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: article
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
       defaults:
+        style: false
+        row: false
         relationships: false
         fields: false
         sorts: false


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
I think this was accidentally overridden when altering front news display

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Go to /livegreen, news area was broken before this change.

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
<img width="896" alt="Screenshot 2023-09-14 at 11 55 01 PM" src="https://github.com/lfucg/lexingtonky.gov/assets/43646355/9862d275-c0dd-414f-89df-bd9829e0efe5">

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you perform a self-review of this PR? | yes
| Documentation reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | Yes
| Did you provide detail in the summary on how and where to test this branch? | Yes
| Relevant links | JIRA issue, bug reports, security alerts, etc.