### PR TITLE
Removes postion: relative from body tag

### DIFF
--- a/web/themes/custom/lex/scss/main.scss
+++ b/web/themes/custom/lex/scss/main.scss
@@ -36,6 +36,10 @@
 html {
   font-size: 100% !important;
   scroll-behavior: smooth;
+
+  body {
+    position: unset !important;
+  }
 }
 
 .no-scroll {


### PR DESCRIPTION
 - not sure where it's being set

## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->

this is to remove position: relative from the body tag, which when removed, fixes a scrolling bug that has been introduced alongside the D10 upgrade.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->

Scroll on any page, and make sure it scrolls as expected.

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you perform a self-review of this PR? | Yes
| Documentation reflects changes? | n/a
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | Yes
| Relevant links | JIRA issue, bug reports, security alerts, etc. https://apaxsoftware.atlassian.net/jira/software/c/projects/LG/boards/68?selectedIssue=LG-155